### PR TITLE
fix: handle null in beforeSequenceClose to prevent crash

### DIFF
--- a/dev/lib/math-tex-flow.js
+++ b/dev/lib/math-tex-flow.js
@@ -284,6 +284,10 @@ function tokenizeMathFenced(effects, ok, nok) {
      * @type {State}
      */
     function beforeSequenceClose(code) {
+      if (code === null) {
+        return nok(code)
+      }
+
       effects.enter('mathFlowFence')
       effects.enter('mathFlowFenceSequence')
       effects.consume(code)

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,13 @@ import {math, mathHtml} from 'micromark-extension-llm-math'
 const renderToString = katex.renderToString
 
 test('math', async function (t) {
+  await t.test('should not break under uncompleted fences', async function () {
+    micromark(`\\[\n   `, {
+      extensions: [math()],
+      htmlExtensions: [mathHtml()]
+    })
+  })
+
   await t.test('should expose the public api', async function () {
     assert.deepEqual(
       Object.keys(await import('micromark-extension-llm-math')).sort(),


### PR DESCRIPTION
## Problem
The parser throws an assertion error when processing incomplete math blocks (with opening fence but no closing fence). This happens because `beforeSequenceClose` attempts to consume a `null` character when it reaches the end of the document while parsing an unclosed math block.

## Solution
Add an early return check in `beforeSequenceClose` to handle the case when `code` is `null`, preventing the assertion error and allowing the parser to gracefully handle incomplete math blocks.

## Test Case
Added a test case that demonstrates the issue with an incomplete math block syntax, ensuring the parser doesn't throw an exception anymore.

## Impact
This fix improves the robustness of the parser by properly handling edge cases with incomplete syntax, which is common in real-world markdown documents especially during editing.