### PR TITLE
Bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micromark-extension-llm-math",
-  "version": "3.1.0",
+  "version": "3.1.1-20250610",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micromark-extension-llm-math",
-      "version": "3.1.0",
+      "version": "3.1.1-20250610",
       "license": "MIT",
       "dependencies": {
         "@types/katex": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromark-extension-llm-math",
-  "version": "3.1.0",
+  "version": "3.1.1-20250610",
   "description": "micromark extension to support math (`$C_L$`, `\\(C_L\\)`)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
I release v3.1.1-20250610.

v3.1.1 will be released in the future by micromark/micromark-extension-math.
Therefore, I need to specify a version number greater than v3.1.0 and less than v3.1.1.
The versioning of npm package follows https://semver.org/.
Thus, I use a pre-release version to represent this intermediate version.